### PR TITLE
arrange block width

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,9 +22,11 @@
     <script src="js/webgl/model.js"></script>
     <script src="js/webgl/shaders.js"></script>
     <script src="js/webgl/webgl.js"></script>
+    <script src="js/block/arrange.js"></script>
     <script src="js/block/block.js"></script>
     <script src="js/block/conncect.js"></script>
     <script src="js/block/global.js"></script>
+    <script src="js/block/requests.js"></script>
     <script src="js/block/tree.js"></script>
     <script src="js/console.js"></script>
     <script src="js/event.js"></script>

--- a/frontend/js/block/arrange.js
+++ b/frontend/js/block/arrange.js
@@ -1,0 +1,83 @@
+/**
+ * A function to arrange block width based on its children.
+ * For example, let `Block` be `Block(width, children array)`:
+ *   * `Block(1, [Block(1, [])])`
+ *   * `Block(2, [null, Block(1, [])])`
+ *   * `Block(3, [Block(1, []), Block(1, [Block(1, []), null])])`
+ * @param {object} block which you want to arrange
+ * @returns {float} sum of width of children
+ */
+function arrange_block_width(block) {
+    if (block === null)
+        return 1.0;
+    if (block[BLOCK_IDX_CHILDREN_NUM] == 0) {
+        block[BLOCK_IDX_WIDTH] = 1.0;
+        return 1.0;
+    }
+    const children_width = block[BLOCK_IDX_CHILDREN].reduce(
+        (res, child) => res + arrange_block_width(child),
+        0
+    );
+    block[BLOCK_IDX_WIDTH] = children_width;
+    if (children_width < block[BLOCK_IDX_CHILDREN_NUM]) {
+        alert(
+            "pyramid frontend exception: number of children is "
+            + block[BLOCK_IDX_CHILDREN_NUM]
+            + " but sum of their width is "
+            + children_width
+            + " so something is wrong with system.");
+    }
+    return children_width;
+}
+/**
+ * A function to arrange blocks.
+ * It determines their width based on children and position based on root.
+ * @param {[object]} blocks which you want to arrange all
+ * @param {float} wr width magnification 
+ * @param {float} hr height magnification 
+ */
+function arrange_blocks(blocks, wr, hr) {
+    blocks.forEach(block => arrange_block_width(block));
+    for_each_blocks(blocks, block => {
+        if (block[BLOCK_IDX_CHILDREN_NUM] == 0)
+            return;
+        let x = block[BLOCK_IDX_X] - block[BLOCK_IDX_WIDTH] * 0.5 * wr;
+        for (const child of block[BLOCK_IDX_CHILDREN]) {
+            if (child === null) {
+                x += wr;
+            } else {
+                const c = child[BLOCK_IDX_WIDTH] * 0.5 * wr;
+                x += c;
+                child[BLOCK_IDX_X] = x;
+                child[BLOCK_IDX_Y] = block[BLOCK_IDX_Y] - BLOCK_HEIGHT * hr;
+                x += c;
+            }
+        }
+    });
+}
+
+
+
+function hoge() {
+    const root = create_block(0, 0, 0, "");
+    const child1 = create_block(0, 0, 0, "");
+    const child2 = create_block(0, 0, 0, "");
+    const child1child1 = create_block(0, 0, 0, "");
+    const child1child2 = create_block(0, 0, 0, "");
+    root[BLOCK_IDX_CHILDREN] = [child1, child2];
+    root[BLOCK_IDX_CHILDREN_NUM] = 2;
+    child1[BLOCK_IDX_PARENT] = root;
+    child1[BLOCK_IDX_CHILDREN] = [];
+    child1[BLOCK_IDX_CHILDREN_NUM] = 0;
+    child2[BLOCK_IDX_PARENT] = root;
+    child2[BLOCK_IDX_CHILDREN] = [child1child1, child1child2];
+    child2[BLOCK_IDX_CHILDREN_NUM] = 2;
+    child1child1[BLOCK_IDX_PARENT] = child2;
+    child1child1[BLOCK_IDX_CHILDREN] = [];
+    child1child1[BLOCK_IDX_CHILDREN_NUM] = 0;
+    child1child2[BLOCK_IDX_PARENT] = child2;
+    child1child2[BLOCK_IDX_CHILDREN] = [];
+    child1child2[BLOCK_IDX_CHILDREN_NUM] = 0;
+    roots.push(root);
+    render();
+}

--- a/frontend/js/block/block.js
+++ b/frontend/js/block/block.js
@@ -1,30 +1,35 @@
 /**
+ * A constructor for block.
+ * @param {float} x coordinate on world
+ * @param {float} y coordinate on world
+ * @param {any} type
+ * @param {any} content
+ */
+function create_block(x, y, type, content) {
+    const children_num = 1;
+    let children = [];
+    for (let i = 0; i < children_num; ++i) {
+        children.push(null);
+    }
+    return [
+        null,
+        children,
+        children_num,
+        x,
+        y,
+        0.0,
+        type,
+        content,
+    ];
+}
+/**
  * A function to push a block to roots array.
+ * @param {object} block which you want to push to roots array
  */
 function push_block_to_roots(block) {
     roots.push(block);
 }
-/**
- * A function to push a new root to roots array.
- */
-function create_and_push_root(x, y, type, content) {
-    let children = [];
-    for (let i = 0; i < 1; ++i) {
-        children.push(null);
-    }
-    const root = [
-        null,
-        children,
-        1,
-        x,
-        y,
-        1.0,
-        0.5,
-        type,
-        content,
-    ];
-    push_block_to_roots(root);
-}
+
 /**
  * A function to remove block from tree in roots.
  */
@@ -43,72 +48,6 @@ function remove_block_from_roots(block_removing) {
         }
     }
     remove_block_(roots);
-}
-/**
- * A function to remove null from blocks.
- */
-function arrangement_blocks(blocks) {
-    for_each_blocks(blocks, block => {
-        for (const child of block[BLOCK_IDX_CHILDREN]) {
-            if (child == null)
-                continue;
-            child[BLOCK_IDX_X] = block[BLOCK_IDX_X];
-            child[BLOCK_IDX_Y] = block[BLOCK_IDX_Y] - block[BLOCK_IDX_HEIGHT];
-        }
-    });
-}
-/**
- * A function to remove null from holding block.
- */
-function arrangement_holding_block() {
-    for_each_blocks([holding_block], block => {
-        const half_width = block[BLOCK_IDX_WIDTH] * 0.5;
-        const half_height = block[BLOCK_IDX_HEIGHT] * 0.5;
-        const pos_view_1 = convert_view_to_clipping([block[BLOCK_IDX_X] - half_width, block[BLOCK_IDX_Y] - half_height, camera[2], 1.0], canvas.width, canvas.height);
-        const pos_view_2 = convert_view_to_clipping([block[BLOCK_IDX_X] + half_width, block[BLOCK_IDX_Y] + half_height, camera[2], 1.0], canvas.width, canvas.height);
-        const h = canvas.height * 0.5 * (pos_view_2[1] / pos_view_2[3] - pos_view_1[1] / pos_view_2[3]);
-        for (const child of block[BLOCK_IDX_CHILDREN]) {
-            if (child == null)
-                continue;
-            child[BLOCK_IDX_X] = block[BLOCK_IDX_X];
-            child[BLOCK_IDX_Y] = block[BLOCK_IDX_Y] - h;
-        }
-    });
-}
-/**
- * A function to push all of block entity requests to requests array.
- */
-function push_requests_blocks(requests) {
-    roots = roots.filter(block => block != null);
-    arrangement_blocks(roots);
-    for_each_blocks(roots, block => {
-        requests.push(
-            entity_block(
-                block[BLOCK_IDX_X],
-                block[BLOCK_IDX_Y],
-                block[BLOCK_IDX_WIDTH],
-                block[BLOCK_IDX_HEIGHT],
-                false
-            )
-        );
-    });
-}
-/**
- * A function to push all of holding blocks entity requests to requests array.
- */
-function push_requests_holding_blocks(requests) {
-    arrangement_holding_block();
-    for_each_blocks([holding_block], block => {
-        requests.push(
-            entity_block(
-                block[BLOCK_IDX_X],
-                block[BLOCK_IDX_Y],
-                block[BLOCK_IDX_WIDTH],
-                block[BLOCK_IDX_HEIGHT],
-                true
-            )
-        );
-    });
 }
 /**
  * A function to find a block which f(block) is true in roots.

--- a/frontend/js/block/conncect.js
+++ b/frontend/js/block/conncect.js
@@ -4,9 +4,8 @@
 function connect_block(){
     const nearest_block = find_block(roots, (block) => {
         return Math.abs(block[BLOCK_IDX_X] - holding_block[BLOCK_IDX_X]) <
-                    (block[BLOCK_IDX_WIDTH] + holding_block[BLOCK_IDX_WIDTH]) / 2
-            && Math.abs(block[BLOCK_IDX_Y] - holding_block[BLOCK_IDX_Y]) <
-                    (block[BLOCK_IDX_HEIGHT] + holding_block[BLOCK_IDX_HEIGHT]) / 2;
+                    (block[BLOCK_IDX_WIDTH] + holding_block[BLOCK_IDX_WIDTH]) * 0.5
+            && Math.abs(block[BLOCK_IDX_Y] - holding_block[BLOCK_IDX_Y]) < BLOCK_HEIGHT;
     });
     if (nearest_block == null) {
         push_block_to_roots(holding_block);

--- a/frontend/js/block/global.js
+++ b/frontend/js/block/global.js
@@ -1,11 +1,14 @@
 let roots = [];
 let holding_block = null;
+
 const BLOCK_IDX_PARENT = 0;
 const BLOCK_IDX_CHILDREN = 1;
 const BLOCK_IDX_CHILDREN_NUM = 2;
 const BLOCK_IDX_X = 3;
 const BLOCK_IDX_Y = 4;
 const BLOCK_IDX_WIDTH = 5;
-const BLOCK_IDX_HEIGHT = 6;
-const BLOCK_IDX_TYPE = 7;
-const BLOCK_IDX_CONTENT = 8;
+const BLOCK_IDX_TYPE = 6;
+const BLOCK_IDX_CONTENT = 7;
+
+const BLOCK_HEIGHT = 0.5;
+const BLOCK_HALF_HEIGHT = 0.25;

--- a/frontend/js/block/requests.js
+++ b/frontend/js/block/requests.js
@@ -1,0 +1,42 @@
+/**
+ * A function to push all of block entity requests to requests array.
+ * @param {[object]} requests 
+ */
+ function push_requests_blocks(requests) {
+    roots = roots.filter(block => block != null);
+    arrange_blocks(roots, 1.0, 1.0);
+    for_each_blocks(roots, block => {
+        requests.push(
+            entity_block(
+                block[BLOCK_IDX_X],
+                block[BLOCK_IDX_Y],
+                Math.max(block[BLOCK_IDX_WIDTH] - 0.6, 1.0),
+                BLOCK_HEIGHT,
+                false
+            )
+        );
+    });
+}
+/**
+ * A function to push all of holding blocks entity requests to requests array.
+ * It depends on `canvas` outer global variable.
+ * @param {[object]} requests 
+ */
+function push_requests_holding_blocks(requests) {
+    const pos_clipping_1 = convert_view_to_clipping([-0.5, -0.5, camera[2], 1.0], canvas.width, canvas.height);
+    const pos_clipping_2 = convert_view_to_clipping([0.5, 0.5, camera[2], 1.0], canvas.width, canvas.height);
+    const wr = canvas.width * 0.5 * (pos_clipping_2[0] / pos_clipping_2[3] - pos_clipping_1[0] / pos_clipping_1[3]);
+    const hr = canvas.height * 0.5 * (pos_clipping_2[1] / pos_clipping_2[3] - pos_clipping_1[1] / pos_clipping_2[3]);
+    arrange_blocks([holding_block], wr, hr);
+    for_each_blocks([holding_block], block => {
+        requests.push(
+            entity_block(
+                block[BLOCK_IDX_X],
+                block[BLOCK_IDX_Y],
+                Math.max(block[BLOCK_IDX_WIDTH] - 0.6, 1.0) * wr,
+                BLOCK_HEIGHT * hr,
+                true
+            )
+        );
+    });
+}

--- a/frontend/js/block/tree.js
+++ b/frontend/js/block/tree.js
@@ -1,7 +1,7 @@
 /**
  * A function to do f for blocks.
- * @param blocks [block; _]
- * @param f fn(block)->void
+ * @param {[object]} blocks which you want to proceed
+ * @param {function(object):void} f which you want to apply to all block in blocks
  */
  function for_each_blocks(blocks, f) {
     if (blocks.length == 0)
@@ -15,9 +15,9 @@
 }
 /**
  * A function to find a block that f(block) is true.
- * @param blocks [block; _]
- * @param f fn(block)->bool 
- * @returns If it's found, then it. Otherwise, null.
+ * @param {[object]} blocks which you want to find a block in
+ * @param {function(object):boolean} f which is true then block is found
+ * @returns {object} If it's found, then it. Otherwise, null.
  */
 function find_block(blocks, f) {
     if (blocks.length == 0)

--- a/frontend/js/console.js
+++ b/frontend/js/console.js
@@ -32,7 +32,7 @@ async function enter() {
                         break;
                     case "generate":
                         const pos_world = convert_2dscreen_to_3dworld([400, 200]);
-                        create_and_push_root(pos_world[0], pos_world[1], 0, content++);
+                        push_block_to_roots(create_block(pos_world[0], pos_world[1], 0, content++));
                         log += "generated at (400, 200) in screen";
                         break;
                     default:
@@ -42,7 +42,7 @@ async function enter() {
                 switch(cmd_array[0]){
                     case "generate":
                         const pos_world = convert_2dscreen_to_3dworld([cmd_array[1], cmd_array[2]]);
-                        create_and_push_root(pos_world[0], pos_world[1], 0, "");
+                        push_block_to_roots(create_block(pos_world[0], pos_world[1], 0, ""));
                         log += "generated at (" + cmd_array[1] + ", " + cmd_array[2] + ") in screen";
                         break;
                     default:

--- a/frontend/js/entity.js
+++ b/frontend/js/entity.js
@@ -27,19 +27,9 @@ function entity_menu() {
 }
 
 function entity_block(x, y, width, height, is_ui) {
-    let w = width;
-    let h = height;
-    if (is_ui) {
-        const half_width = width * 0.5;
-        const half_height = height * 0.5;
-        const pos_view_1 = convert_view_to_clipping([x - half_width, y - half_height, camera[2], 1.0], canvas.width, canvas.height);
-        const pos_view_2 = convert_view_to_clipping([x + half_width, y + half_height, camera[2], 1.0], canvas.width, canvas.height);
-        w = canvas.width * 0.5 * (pos_view_2[0] / pos_view_2[3] - pos_view_1[0] / pos_view_1[3]);
-        h = canvas.height * 0.5 * (pos_view_2[1] / pos_view_2[3] - pos_view_1[1] / pos_view_2[3]);
-    }
     return [
         [x, y, 0.0],
-        [w, h, 1.0],
+        [width, height, 1.0],
         [0.0, 0.0, 1.0, 1.0],
         null,
         [0.0, 0.0, 0.0, 0.0],

--- a/frontend/js/event.js
+++ b/frontend/js/event.js
@@ -12,9 +12,8 @@ function fun_mousedown(event) {
             const pos_world = convert_2dscreen_to_3dworld([event.pageX, event.pageY]);
             const hit_result = find_block_from_roots((block) => {
                 const block_half_width = block[BLOCK_IDX_WIDTH] * 0.5;
-                const block_half_height = block[BLOCK_IDX_HEIGHT] * 0.5;
                 return Math.abs(block[BLOCK_IDX_X] - pos_world[0]) < block_half_width
-                    && Math.abs(block[BLOCK_IDX_Y] - pos_world[1]) < block_half_height;
+                    && Math.abs(block[BLOCK_IDX_Y] - pos_world[1]) < BLOCK_HALF_HEIGHT;
             });
             if(hit_result != null){
                 holding_block = hit_result;


### PR DESCRIPTION
Close #36 
子供の数、その幅に応じてブロックを伸縮するようにした。ただし、今は伸縮率が固定であるためか、葉より上は直方体のようになってしまっている。
ついでに、ブロックを作るための関数と、そのブロックを`roots`に入れる関数とを分けた。
arrange.jsに`hoge`関数がある。これをブラウザのデバッガーツールのコンソールで呼び出すと、`Block(Block(), Block(Block(), Block()))`が現れるので試してみて欲しい。