### PR TITLE
NaNをNumber型で認識される予約語に変更した

### DIFF
--- a/ts/evaluation/pyramid_number.ts
+++ b/ts/evaluation/pyramid_number.ts
@@ -15,6 +15,7 @@ export class PyramidNumber {
     // Number("") = 0
     // Number(undefined) = NaN
     static check_type(value: string): boolean {
+        if (value === "NaN") return true
         if (value === "0") return true
         const temp = Number(value);
         if (Number.isNaN(temp) || temp === 0) return false


### PR DESCRIPTION
NaN（非数）は浮動小数の規格IEEE754に組み込まれた立派な数なので、"NaN"はNumber型であるように修正した。

これによって、正しくPyramid Backend Errorが呼ばれるようになった。